### PR TITLE
fix: 環境変数の設定を修正

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -21,7 +21,7 @@ export const props: EnvironmentProps = {
 
   // WAF設定 - 環境変数からIPアドレスを読み取り
   // 環境変数が設定されていない場合は、すべてのIPアドレスを許可（デフォルト）
-  allowedIPv4Cidrs: parseIpAddresses(process.env.ALLOWED_IPV4_CIDRS) || ['0.0.0.0/0'],
+  allowedIPv4Cidrs: parseIpAddresses(process.env.ALLOWED_IPV4_CIDRS),
   allowedIPv6Cidrs: parseIpAddresses(process.env.ALLOWED_IPV6_CIDRS),
   allowedCountryCodes: parseIpAddresses(process.env.ALLOWED_COUNTRY_CODES),
 

--- a/set-env.sh
+++ b/set-env.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # POC (Dify Dev)
-export CDK_DEFAULT_ACCOUNT=
-
-# AI (Dify Prod)
 # export CDK_DEFAULT_ACCOUNT=
 
+# AI (Dify Prod)
+export CDK_DEFAULT_ACCOUNT=
+
+# IP Addresses
 export ALLOWED_IPV4_CIDRS=
 export ALLOWED_COUNTRY_CODES=


### PR DESCRIPTION
- CDK_DEFAULT_ACCOUNTのエクスポートを修正
- ALLOWED_IPV4_CIDRSのデフォルト値を削除し、環境変数からの読み取りに変更