### PR TITLE
refactor: use GitHub Variables instead of Secrets for IP restrictions

### DIFF
--- a/.github/workflows/cdk-workflow.yml
+++ b/.github/workflows/cdk-workflow.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           export CDK_DEFAULT_ACCOUNT=${{ secrets.AWS_ACCOUNT_ID }}
           export CDK_DEFAULT_REGION=us-west-2
-          export ALLOWED_IPV4_CIDRS="${{ secrets.ALLOWED_IPV4_CIDRS }}"
-          export ALLOWED_COUNTRY_CODES="${{ secrets.ALLOWED_COUNTRY_CODES }}"
+          export ALLOWED_IPV4_CIDRS="${{ vars.ALLOWED_IPV4_CIDRS }}"
+          export ALLOWED_COUNTRY_CODES="${{ vars.ALLOWED_COUNTRY_CODES }}"
 
           # CDK diffを実行し、結果を取得（マルチリージョン対応）
           diff=$(npx cdk diff --all 2>&1) || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,8 @@ jobs:
         run: |
           export CDK_DEFAULT_ACCOUNT=${{ secrets.AWS_ACCOUNT_ID }}
           export CDK_DEFAULT_REGION=us-west-2
-          export ALLOWED_IPV4_CIDRS="${{ secrets.ALLOWED_IPV4_CIDRS }}"
-          export ALLOWED_COUNTRY_CODES="${{ secrets.ALLOWED_COUNTRY_CODES }}"
+          export ALLOWED_IPV4_CIDRS="${{ vars.ALLOWED_IPV4_CIDRS }}"
+          export ALLOWED_COUNTRY_CODES="${{ vars.ALLOWED_COUNTRY_CODES }}"
 
           cdk deploy --all --require-approval never
         # すべての CDK スタックをデプロイ


### PR DESCRIPTION
IP addresses and country codes are not sensitive data, so they should be stored in Variables for easier debugging and management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)