### PR TITLE
fix:  ECS タスクサイズアップ

### DIFF
--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -53,8 +53,8 @@ export class ApiService extends Construct {
     const volumeName = 'sandbox';
 
     const taskDefinition = new FargateTaskDefinition(this, 'Task', {
-      cpu: 1024,
-      memoryLimitMiB: 2048, // We got OOM frequently when RAM=512MB
+      cpu: 2048,
+      memoryLimitMiB: 4096, // Upsized from 1024/2048 to fix CPU exhaustion (105% usage observed)
       runtimePlatform: { cpuArchitecture: CpuArchitecture.X86_64 },
       volumes: [
         {

--- a/lib/constructs/redis.ts
+++ b/lib/constructs/redis.ts
@@ -40,7 +40,7 @@ export class Redis extends Construct implements ec2.IConnectable {
 
     const redis = new CfnReplicationGroup(this, 'Resource', {
       engine: 'Valkey',
-      cacheNodeType: 'cache.t4g.micro',
+      cacheNodeType: 'cache.t4g.small',
       engineVersion: '8.0',
       cacheParameterGroupName: 'default.valkey8',
       port: this.port,

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -2459,7 +2459,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
             ],
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "ApiServiceTaskExecutionRoleFE812553",
@@ -2467,7 +2467,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
           ],
         },
         "Family": "TestStackApiServiceTaskBFA8CBF7",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -3699,7 +3699,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
           ],
         },
         "AutomaticFailoverEnabled": true,
-        "CacheNodeType": "cache.t4g.micro",
+        "CacheNodeType": "cache.t4g.small",
         "CacheParameterGroupName": "default.valkey8",
         "CacheSubnetGroupName": {
           "Ref": "RedisSubnetGroup2387CBFF",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -2119,7 +2119,7 @@ exports[`Snapshot test 1`] = `
             ],
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "ApiServiceTaskExecutionRoleFE812553",
@@ -2127,7 +2127,7 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "Family": "TestStackApiServiceTaskBFA8CBF7",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -3018,7 +3018,7 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "AutomaticFailoverEnabled": true,
-        "CacheNodeType": "cache.t4g.micro",
+        "CacheNodeType": "cache.t4g.small",
         "CacheParameterGroupName": "default.valkey8",
         "CacheSubnetGroupName": {
           "Ref": "RedisSubnetGroup2387CBFF",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -2101,7 +2101,7 @@ exports[`Snapshot test 1`] = `
             ],
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "ApiServiceTaskExecutionRoleFE812553",
@@ -2109,7 +2109,7 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "Family": "TestStackApiServiceTaskBFA8CBF7",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -3022,7 +3022,7 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "AutomaticFailoverEnabled": true,
-        "CacheNodeType": "cache.t4g.micro",
+        "CacheNodeType": "cache.t4g.small",
         "CacheParameterGroupName": "default.valkey8",
         "CacheSubnetGroupName": {
           "Ref": "RedisSubnetGroup2387CBFF",


### PR DESCRIPTION
## 概要

ECS API タスクの CPU 使用率が 105%・メモリ使用率が 99.76% に達し、タスクがクラッシュと再起動を繰り返していた問題を修正します。

関連調査レポート: [`docs/root-cause-confirmed.md`](./docs/root-cause-confirmed.md)

## 変更内容

### `lib/constructs/dify-services/api.ts` — ECS タスクサイズアップ

| 項目 | 変更前 | 変更後 |
|---|---|---|
| CPU | 1 vCPU | **2 vCPU** |
| メモリ | 2 GB | **4 GB** |

### `lib/constructs/redis.ts` — Redis ノードサイズアップ

| 項目 | 変更前 | 変更後 |
|---|---|---|
| ノードタイプ | cache.t4g.micro（0.5 GB） | **cache.t4g.small（1.4 GB）** |

## 追加コスト

| 変更 | 月額差分 |
|---|---|
| ECS タスクサイズアップ | +~$10.7/月 |
| Redis サイズアップ | +~$9.2/月 |
| **合計** | **+~$20/月（約3,000円/月）** |

## なぜこの変更が必要か

1 vCPU / 2 GB RAM のタスクに API サーバー・PluginDaemon・Sandbox・Worker の複数プロセスが詰め込まれており、物理的にリソースが不足していました。Dify 1.11.1 へのアップグレードおよび WORKER_TIMEOUT の延長（15秒 → 180秒）が重なり、CPU 使用量が限界を超えた状態です。

## テスト

- CDK スナップショット更新済み・全テスト通過 ✅
- デプロイ後、Container Insights で CPU・メモリの改善を確認予定
